### PR TITLE
Changed Hashes.org -> HashMob

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You are encouraged to train using your own password leaks and datasets. Some gre
 
 - [LinkedIn leak](https://github.com/brannondorsey/PassGAN/releases/download/data/68_linkedin_found_hash_plain.txt.zip) (1.7GB compressed, direct download. Mirror from [Hashes.org](https://hashes.org/leaks.php))
 - [Exploit.in torrent](https://thepiratebay.org/torrent/16016494/exploit.in) (10GB+, 800 million accounts. Infamous!)
-- [Hashes.org](https://hashes.org/leaks.php): Awesome shared password recovery site. Consider donating if you have the resources ;)
+- [HashMob.net](https://hashmob.net/research/wordlists): Awesome shared password recovery site. Consider donating if you have the resources ;)
 
 
 


### PR DESCRIPTION
After Hashes.org went down, HashMob kind of took it's place, taking over a majority of its dataset with a large overlap in community.